### PR TITLE
Handle slug-based product pages and add tests

### DIFF
--- a/app/Http/Controllers/Frontend/ProductController.php
+++ b/app/Http/Controllers/Frontend/ProductController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
+use App\Models\Product;
 use Illuminate\Http\Request;
+use Illuminate\View\View;
 
 final class ProductController extends Controller
 {
@@ -15,9 +17,24 @@ final class ProductController extends Controller
         return response()->json(['message' => 'Product listing not implemented yet']);
     }
 
-    public function show(string $id)
+    public function show(Product $product): View
     {
-        // TODO: Implement product details
-        return response()->json(['message' => 'Product details not implemented yet', 'id' => $id]);
+        $product->loadMissing([
+            'brand',
+            'categories',
+            'media',
+            'reviews',
+            'attributes.values',
+            'variants' => static function ($query): void {
+                $query->with([
+                    'images',
+                    'attributes.attribute',
+                ]);
+            },
+        ]);
+
+        return view('products.show', [
+            'product' => $product,
+        ]);
     }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -720,6 +720,31 @@ final class Product extends Model implements HasMedia
     }
 
     /**
+     * Handle scopeEnabled functionality with proper error handling.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     */
+    public function scopeEnabled($query)
+    {
+        $schema = $this->getConnection()->getSchemaBuilder();
+        $table = $this->getTable();
+
+        if ($schema->hasColumn($table, 'is_enabled')) {
+            return $query->where('is_enabled', true);
+        }
+
+        if ($schema->hasColumn($table, 'is_active')) {
+            return $query->where('is_active', true);
+        }
+
+        if ($schema->hasColumn($table, 'status')) {
+            return $query->where('status', 'published');
+        }
+
+        return $query;
+    }
+
+    /**
      * Handle scopeFeatured functionality with proper error handling.
      *
      * @param  mixed  $query

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -1,0 +1,8 @@
+@extends('components.layouts.base')
+
+@section('title', $product->seo_title ?? $product->name)
+@section('description', $product->seo_description ?? \Illuminate\Support\Str::limit(strip_tags($product->short_description ?? ''), 160))
+
+@section('content')
+    <livewire:product-page :product="$product" />
+@endsection

--- a/routes/frontend.php
+++ b/routes/frontend.php
@@ -25,7 +25,7 @@ Route::middleware(['web'])->group(function () {
         Route::get('/search', [App\Http\Controllers\Frontend\ProductController::class, 'search'])->name('search');
         Route::get('/category/{category}', [App\Http\Controllers\Frontend\ProductController::class, 'byCategory'])->name('by-category');
         Route::get('/brand/{brand}', [App\Http\Controllers\Frontend\ProductController::class, 'byBrand'])->name('by-brand');
-        Route::get('/{product}', [App\Http\Controllers\Frontend\ProductController::class, 'show'])->name('show');
+        Route::get('/{product:slug}', [App\Http\Controllers\Frontend\ProductController::class, 'show'])->name('show');
         Route::post('/{product}/review', [App\Http\Controllers\Frontend\ProductController::class, 'addReview'])->name('add-review');
     });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -403,7 +403,7 @@ Route::get('/', function () {
 // Backward-compatible redirect
 Route::get('/home', fn() => redirect()->route('home'));
 Route::get('/products', Pages\ProductCatalog::class)->name('products.index');
-Route::get('/products/{product}', Pages\SingleProduct::class)->name('products.show');
+Route::get('/products/{product:slug}', [App\Http\Controllers\Frontend\ProductController::class, 'show'])->name('products.show');
 Route::get('/products/{product}/history', Pages\ProductHistoryPage::class)->name('products.history');
 
 // Product Request routes (authenticated users only)

--- a/tests/frontend/features/ProductPageTest.php
+++ b/tests/frontend/features/ProductPageTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Frontend;
+
+use App\Models\Brand;
+use App\Models\Product;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class ProductPageTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['activitylog.enabled' => false]);
+
+        Schema::disableForeignKeyConstraints();
+        Schema::dropAllTables();
+        Schema::enableForeignKeyConstraints();
+
+        File::ensureDirectoryExists(public_path('build'));
+        File::put(
+            public_path('build/manifest.json'),
+            json_encode([
+                'resources/css/app.scss' => [
+                    'file' => 'assets/app.css',
+                    'isEntry' => true,
+                    'src' => 'resources/css/app.scss',
+                ],
+                'resources/js/app.js' => [
+                    'file' => 'assets/app.js',
+                    'isEntry' => true,
+                    'src' => 'resources/js/app.js',
+                ],
+            ], JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT)
+        );
+
+        Schema::create('brands', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->string('website')->nullable();
+            $table->boolean('is_enabled')->default(true);
+            $table->boolean('is_active')->default(true);
+            $table->boolean('is_visible')->default(true);
+            $table->boolean('is_featured')->default(false);
+            $table->string('seo_title')->nullable();
+            $table->string('seo_description')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('products', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('brand_id')->nullable()->constrained('brands');
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('sku')->unique();
+            $table->text('description')->nullable();
+            $table->text('short_description')->nullable();
+            $table->string('type')->default('simple');
+            $table->decimal('price', 12, 2)->nullable();
+            $table->decimal('compare_price', 12, 2)->nullable();
+            $table->decimal('sale_price', 12, 2)->nullable();
+            $table->decimal('weight', 12, 2)->nullable();
+            $table->decimal('length', 12, 2)->nullable();
+            $table->decimal('width', 12, 2)->nullable();
+            $table->decimal('height', 12, 2)->nullable();
+            $table->boolean('is_visible')->default(true);
+            $table->boolean('is_featured')->default(false);
+            $table->boolean('is_requestable')->default(false);
+            $table->boolean('hide_add_to_cart')->default(false);
+            $table->string('status')->default('draft');
+            $table->boolean('manage_stock')->default(false);
+            $table->boolean('track_stock')->default(false);
+            $table->integer('stock_quantity')->default(0);
+            $table->integer('low_stock_threshold')->default(0);
+            $table->string('seo_title')->nullable();
+            $table->string('seo_description')->nullable();
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('categories', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->text('short_description')->nullable();
+            $table->foreignId('parent_id')->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->boolean('is_visible')->default(true);
+            $table->boolean('is_enabled')->default(true);
+            $table->boolean('is_active')->default(true);
+            $table->boolean('is_featured')->default(false);
+            $table->boolean('show_in_menu')->default(false);
+            $table->integer('product_limit')->nullable();
+            $table->string('seo_title')->nullable();
+            $table->string('seo_description')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('product_categories', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('product_id')->constrained('products')->cascadeOnDelete();
+            $table->foreignId('category_id')->constrained('categories')->cascadeOnDelete();
+        });
+
+        Schema::create('reviews', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('product_id')->constrained('products')->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable();
+            $table->string('reviewer_name')->nullable();
+            $table->string('reviewer_email')->nullable();
+            $table->unsignedTinyInteger('rating')->default(5);
+            $table->string('title')->nullable();
+            $table->text('content')->nullable();
+            $table->boolean('is_approved')->default(true);
+            $table->boolean('is_featured')->default(false);
+            $table->string('locale')->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamp('rejected_at')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('media', function (Blueprint $table): void {
+            $table->id();
+            $table->uuid('uuid')->nullable();
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+            $table->string('collection_name');
+            $table->string('name');
+            $table->string('file_name');
+            $table->string('mime_type')->nullable();
+            $table->string('disk');
+            $table->string('conversions_disk')->nullable();
+            $table->unsignedBigInteger('size')->default(0);
+            $table->json('manipulations');
+            $table->json('custom_properties');
+            $table->json('generated_conversions');
+            $table->json('responsive_images');
+            $table->unsignedInteger('order_column')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('product_variants', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('product_id')->constrained('products')->cascadeOnDelete();
+            $table->string('name')->nullable();
+            $table->string('sku')->nullable();
+            $table->decimal('price', 12, 2)->nullable();
+            $table->boolean('is_enabled')->default(true);
+            $table->boolean('is_active')->default(true);
+            $table->string('status')->default('active');
+            $table->integer('stock_quantity')->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('variant_images', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('variant_id')->constrained('product_variants')->cascadeOnDelete();
+            $table->string('path')->nullable();
+            $table->boolean('is_primary')->default(false);
+            $table->timestamps();
+        });
+
+        Schema::create('attributes', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->boolean('is_enabled')->default(true);
+            $table->boolean('is_active')->default(true);
+            $table->boolean('is_visible')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('attribute_values', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('attribute_id')->constrained('attributes')->cascadeOnDelete();
+            $table->string('value');
+            $table->string('slug')->unique();
+            $table->string('display_value')->nullable();
+            $table->boolean('is_enabled')->default(true);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('product_variant_attributes', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('variant_id')->constrained('product_variants')->cascadeOnDelete();
+            $table->foreignId('attribute_value_id')->constrained('attribute_values')->cascadeOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('product_attributes', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('product_id')->constrained('products')->cascadeOnDelete();
+            $table->foreignId('attribute_id')->constrained('attributes')->cascadeOnDelete();
+            $table->foreignId('attribute_value_id')->nullable()->constrained('attribute_values')->nullOnDelete();
+            $table->timestamps();
+        });
+
+        Schema::create('product_translations', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('product_id')->constrained('products')->cascadeOnDelete();
+            $table->string('locale');
+            $table->string('name')->nullable();
+            $table->string('slug')->nullable();
+            $table->text('description')->nullable();
+            $table->text('short_description')->nullable();
+            $table->string('seo_title')->nullable();
+            $table->string('seo_description')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('brand_translations', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('brand_id')->constrained('brands')->cascadeOnDelete();
+            $table->string('locale');
+            $table->string('name')->nullable();
+            $table->string('slug')->nullable();
+            $table->text('description')->nullable();
+            $table->string('seo_title')->nullable();
+            $table->string('seo_description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function test_product_page_displays_product_details(): void
+    {
+        $brand = Brand::factory()->create([
+            'is_visible' => true,
+            'is_active' => true,
+            'is_enabled' => true,
+        ]);
+
+        $price = 129.95;
+
+        $product = Product::factory()->create([
+            'brand_id' => $brand->id,
+            'name' => 'Test Hammer',
+            'slug' => 'test-hammer',
+            'sku' => 'HAMMER-001',
+            'price' => $price,
+            'short_description' => 'A durable hammer for testing.',
+            'status' => 'published',
+            'is_visible' => true,
+            'published_at' => now()->subHour(),
+            'manage_stock' => false,
+            'track_stock' => false,
+            'stock_quantity' => 50,
+        ]);
+
+        $response = $this->get('/products/'.$product->slug);
+
+        $response->assertOk();
+        $response->assertSee('Test Hammer');
+        $response->assertSee('€'.number_format($price, 2), false);
+        $response->assertSee('HAMMER-001');
+        $response->assertSee('A durable hammer for testing.');
+    }
+}

--- a/tests/frontend/features/RouteTest.php
+++ b/tests/frontend/features/RouteTest.php
@@ -90,8 +90,20 @@ class RouteTest extends TestCase
         Category::factory()->create();
 
         // Create products
-        Product::factory()->create();
-        Product::factory()->create();
+        Product::factory()->create([
+            'status' => 'published',
+            'is_visible' => true,
+            'published_at' => now()->subDay(),
+            'stock_quantity' => 25,
+            'manage_stock' => true,
+        ]);
+        Product::factory()->create([
+            'status' => 'published',
+            'is_visible' => true,
+            'published_at' => now()->subHours(2),
+            'stock_quantity' => 12,
+            'manage_stock' => true,
+        ]);
 
         // Create brands
         \App\Models\Brand::factory()->create();
@@ -235,14 +247,15 @@ class RouteTest extends TestCase
      */
     public function test_product_routes(): void
     {
-        $product = Product::first();
+        $product = Product::query()->first();
+        $this->assertNotNull($product);
 
         // Test product catalog
         $response = $this->get('/products');
         $response->assertStatus(200);
 
         // Test single product
-        $response = $this->get("/products/{$product->id}");
+        $response = $this->get("/products/{$product->slug}");
         $response->assertStatus(200);
 
         // Test product history
@@ -716,8 +729,9 @@ class RouteTest extends TestCase
         $response = $this->get('/lt/products');
         $response->assertStatus(200);
 
-        $product = Product::first();
-        $response = $this->get("/lt/products/{$product->id}");
+        $product = Product::query()->first();
+        $this->assertNotNull($product);
+        $response = $this->get("/lt/products/{$product->slug}");
         $response->assertStatus(200);
 
         $response = $this->get("/lt/products/{$product->id}/history");


### PR DESCRIPTION
## Summary
- resolve the frontend product show route by slug-bound Product instances and eager-load the data needed for the Livewire view
- add a lightweight Blade wrapper for the product page and introduce a resilient Product::scopeEnabled() implementation
- expand feature coverage with a dedicated product page test (including test schema + Vite manifest stubs) and adjust route tests to hit slug-based product URLs

## Testing
- vendor/bin/pest tests/frontend/features/ProductPageTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dfc14a755083298b5941e0451bf5da