### PR TITLE
Emit variant selected events when changing variants

### DIFF
--- a/app/Livewire/ProductVariantSelector.php
+++ b/app/Livewire/ProductVariantSelector.php
@@ -71,8 +71,14 @@ final class ProductVariantSelector extends Component
         }
 
         if ($defaultVariant) {
+            $previousVariantId = $this->selectedVariant?->id;
+
             $this->selectedVariant = $defaultVariant;
             $this->selectedAttributes = $this->getVariantAttributes($defaultVariant);
+
+            if ($defaultVariant->id !== $previousVariantId) {
+                $this->dispatch('variant.selected', variantId: $defaultVariant->id);
+            }
         }
     }
 
@@ -104,8 +110,14 @@ final class ProductVariantSelector extends Component
             return true;
         });
 
+        $previousVariantId = $this->selectedVariant?->id;
+
         $this->selectedVariant = $matchingVariant;
         $this->showVariantDetails = $matchingVariant !== null;
+
+        if ($matchingVariant && $matchingVariant->id !== $previousVariantId) {
+            $this->dispatch('variant.selected', variantId: $matchingVariant->id);
+        }
     }
 
     public function getVariantAttributes(ProductVariant $variant): array


### PR DESCRIPTION
## Summary
- dispatch `variant.selected` when the default variant is chosen
- emit `variant.selected` when attribute selections change the current variant
- ensure events only fire when a real variant is selected

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfd871eb5883298c2a45c352ce8662