### PR TITLE
Add Livewire variant selection handler and tests

### DIFF
--- a/app/Livewire/ProductVariantSelector.php
+++ b/app/Livewire/ProductVariantSelector.php
@@ -108,11 +108,49 @@ final class ProductVariantSelector extends Component
         $this->showVariantDetails = $matchingVariant !== null;
     }
 
+    public function onVariantSelected(?int $variantId): void
+    {
+        if ($variantId === null) {
+            $this->resetVariantSelection();
+
+            return;
+        }
+
+        $variant = $this->variants->firstWhere('id', $variantId);
+
+        if (! $variant) {
+            $this->resetVariantSelection();
+
+            return;
+        }
+
+        $this->selectedVariant = $variant;
+        $this->selectedAttributes = $this->getVariantAttributes($variant);
+        $this->showVariantDetails = true;
+        $this->quantity = 1;
+
+        $this->recordVariantClick();
+    }
+
+    private function resetVariantSelection(): void
+    {
+        $this->selectedVariant = null;
+        $this->selectedAttributes = [];
+        $this->showVariantDetails = false;
+        $this->quantity = 1;
+    }
+
     public function getVariantAttributes(ProductVariant $variant): array
     {
         $attributes = [];
 
-        foreach ($variant->attributes as $attributeValue) {
+        $attributeValues = $variant->getRelationValue('attributes');
+
+        if ($attributeValues === null) {
+            $attributeValues = $variant->attributes()->with('attribute')->get();
+        }
+
+        foreach ($attributeValues as $attributeValue) {
             $attributes[$attributeValue->attribute->slug] = $attributeValue->value;
         }
 
@@ -220,19 +258,23 @@ final class ProductVariantSelector extends Component
 
     public function getVariantPrice(): float
     {
-        return $this->selectedVariant ? $this->selectedVariant->getCurrentPrice() : 0;
+        return $this->selectedVariant ? (float) $this->selectedVariant->getCurrentPrice() : 0.0;
     }
 
     public function getVariantOriginalPrice(): float
     {
-        return $this->selectedVariant ? $this->selectedVariant->price : 0;
+        return $this->selectedVariant ? (float) $this->selectedVariant->price : 0.0;
     }
 
     public function getVariantPromotionalPrice(): ?float
     {
-        return $this->selectedVariant && $this->selectedVariant->isCurrentlyOnSale()
-            ? $this->selectedVariant->promotional_price
-            : null;
+        if (! $this->selectedVariant || ! $this->selectedVariant->isCurrentlyOnSale()) {
+            return null;
+        }
+
+        $promotionalPrice = $this->selectedVariant->promotional_price;
+
+        return $promotionalPrice !== null ? (float) $promotionalPrice : null;
     }
 
     public function isVariantOnSale(): bool
@@ -363,6 +405,8 @@ final class ProductVariantSelector extends Component
 
     public function render()
     {
-        return view('livewire.product-variant-selector');
+        return view('livewire.product-variant-selector', [
+            'attributes' => $this->variantAttributes,
+        ]);
     }
 }

--- a/app/Models/ProductVariant.php
+++ b/app/Models/ProductVariant.php
@@ -111,10 +111,10 @@ final class ProductVariant extends Model implements HasMedia
      */
     public function reservedQuantity(): int
     {
-        $variantId = Number::parseFloat($this->id);
-        $sum = Number::parseFloat(DB::table('variant_inventories as vi')->where('vi.variant_id', $variantId)->sum('vi.reserved'));
+        $variantId = Number::parseFloat((string) $this->id);
+        $sum = Number::parseFloat((string) DB::table('variant_inventories as vi')->where('vi.variant_id', $variantId)->sum('vi.reserved'));
 
-        return max($sum, 0);
+        return (int) max($sum, 0);
     }
 
     /**
@@ -122,10 +122,10 @@ final class ProductVariant extends Model implements HasMedia
      */
     public function availableQuantity(): int
     {
-        $variantId = Number::parseFloat($this->id);
-        $sum = Number::parseFloat(DB::table('variant_inventories as vi')->where('vi.variant_id', $variantId)->sum(DB::raw('CASE WHEN (vi.stock - vi.reserved) > 0 THEN (vi.stock - vi.reserved) ELSE 0 END')));
+        $variantId = Number::parseFloat((string) $this->id);
+        $sum = Number::parseFloat((string) DB::table('variant_inventories as vi')->where('vi.variant_id', $variantId)->sum(DB::raw('CASE WHEN (vi.stock - vi.reserved) > 0 THEN (vi.stock - vi.reserved) ELSE 0 END')));
 
-        return max($sum, 0);
+        return (int) max($sum, 0);
     }
 
     /**

--- a/tests/Feature/Livewire/ProductVariantSelectorTest.php
+++ b/tests/Feature/Livewire/ProductVariantSelectorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\ProductVariantSelector;
+use App\Models\Product;
+use App\Models\ProductVariant;
+use Livewire\Livewire;
+
+describe('ProductVariantSelector', function (): void {
+    it('selects the requested variant and resets dependent state when the variantSelected event is received', function (): void {
+        $product = Product::factory()->create([
+            'status' => 'published',
+            'is_visible' => true,
+            'published_at' => now(),
+        ]);
+
+        $variants = ProductVariant::factory()
+            ->count(2)
+            ->for($product)
+            ->create();
+
+        $component = Livewire::test(ProductVariantSelector::class, ['product' => $product]);
+
+        $component->set('quantity', 3);
+
+        $selectedVariant = $variants->last();
+
+        $component->dispatch('variantSelected', $selectedVariant->id);
+
+        $component
+            ->assertSet('selectedVariant.id', $selectedVariant->id)
+            ->assertSet('selectedAttributes', [])
+            ->assertSet('showVariantDetails', true)
+            ->assertSet('quantity', 1);
+
+        $component->dispatch('variantSelected', null);
+
+        $component
+            ->assertSet('selectedVariant', null)
+            ->assertSet('selectedAttributes', [])
+            ->assertSet('showVariantDetails', false)
+            ->assertSet('quantity', 1);
+    });
+});


### PR DESCRIPTION
## Summary
- add an onVariantSelected listener that syncs the selected variant, attributes, details visibility, and quantity defaults
- harden variant attribute hydration and pricing helpers to avoid type issues when rendering the selector
- normalize ProductVariant inventory helpers and cover the new event path with a Livewire feature test

## Testing
- ./vendor/bin/pest tests/Feature/Livewire/ProductVariantSelectorTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dfd87206b48329ae747fcd3224e270