### PR TITLE
Enhance product variant feature display on product page

### DIFF
--- a/app/Livewire/Pages/SingleProduct.php
+++ b/app/Livewire/Pages/SingleProduct.php
@@ -174,26 +174,91 @@ final class SingleProduct extends Component
             $this->product->loadMissing(['attributes.values']);
         }
 
-        return $this
+        if (! $this->product->relationLoaded('variants')) {
+            $this->product->loadMissing(['variants.values.attribute']);
+        }
+
+        $variantFeatures = collect();
+
+        $variantFeatures = $this
+            ->product
+            ->variants
+            ->flatMap(function (ProductVariant $variant) {
+                if (! $variant->relationLoaded('values')) {
+                    $variant->loadMissing(['values.attribute']);
+                }
+
+                return $variant
+                    ->values
+                    ->map(function ($value): array {
+                        $attribute = $value->attribute;
+
+                        return [
+                            'id' => $attribute?->id,
+                            'label' => $attribute?->trans('name') ?? $attribute?->name,
+                            'value' => $value->trans('value') ?? $value->value,
+                            'icon' => $attribute?->icon,
+                            'color' => $attribute?->color,
+                        ];
+                    });
+            })
+            ->filter(fn (array $feature) => filled($feature['id']) && filled($feature['value']))
+            ->groupBy('id')
+            ->map(function ($group): array {
+                $first = $group->first();
+
+                return [
+                    'id' => $first['id'],
+                    'label' => $first['label'],
+                    'value' => $group->pluck('value')->filter()->unique()->implode(', '),
+                    'icon' => $first['icon'],
+                    'color' => $first['color'],
+                ];
+            });
+
+        $variantFeaturesById = $variantFeatures->keyBy('id');
+
+        $productFeatures = $this
             ->product
             ->attributes
-            ->map(function ($attribute): array {
-                $valueId = $attribute->pivot->attribute_value_id ?? null;
+            ->map(function ($attribute) use ($variantFeaturesById): array {
                 $value = null;
+                $valueId = $attribute->pivot->attribute_value_id ?? null;
 
                 if ($valueId) {
                     $valueModel = $attribute->values->firstWhere('id', $valueId);
                     $value = $valueModel ? ($valueModel->trans('value') ?? $valueModel->value) : null;
                 }
 
+                if (! filled($value) && $variantFeaturesById->has($attribute->id)) {
+                    $value = $variantFeaturesById->get($attribute->id)['value'];
+                }
+
+                $icon = $attribute->icon;
+                $color = $attribute->color;
+
+                if ($variantFeaturesById->has($attribute->id)) {
+                    $variantFeature = $variantFeaturesById->get($attribute->id);
+                    $icon = $icon ?: $variantFeature['icon'];
+                    $color = $color ?: $variantFeature['color'];
+                }
+
                 return [
                     'id' => $attribute->id,
                     'label' => $attribute->trans('name') ?? $attribute->name,
                     'value' => $value,
-                    'icon' => $attribute->icon,
+                    'icon' => $icon,
+                    'color' => $color,
                 ];
             })
             ->filter(fn (array $feature) => filled($feature['value']))
+            ->keyBy('id');
+
+        $combined = $productFeatures->union($variantFeaturesById);
+
+        return $combined
+            ->filter(fn (array $feature) => filled($feature['value']))
+            ->sortBy('label', SORT_NATURAL | SORT_FLAG_CASE)
             ->values();
     }
 

--- a/resources/views/livewire/pages/single-product.blade.php
+++ b/resources/views/livewire/pages/single-product.blade.php
@@ -167,15 +167,38 @@
                             @else
                                 <div class="grid gap-4 sm:grid-cols-2">
                                     @foreach ($this->attributeFeatures as $feature)
+                                        @php
+                                            $iconComponent = $feature['icon'] ?? null;
+                                            $iconColor = $feature['color'] ?? null;
+                                            $resolvedIcon = null;
+
+                                            if ($iconComponent) {
+                                                if (\Illuminate\Support\Str::startsWith($iconComponent, 'heroicon-')) {
+                                                    $resolvedIcon = $iconComponent;
+                                                } elseif (! \Illuminate\Support\Str::contains($iconComponent, '::')) {
+                                                    $resolvedIcon = 'heroicon-o-' . $iconComponent;
+                                                }
+                                            }
+                                        @endphp
                                         <div
-                                             class="flex items-start gap-3 rounded-2xl border border-slate-100 bg-slate-50/60 p-4">
+                                             class="flex items-start gap-3 rounded-2xl border border-slate-100 bg-white/70 p-4 shadow-sm">
                                             <div
-                                                 class="flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-sm">
-                                                <x-heroicon-o-check-badge class="h-5 w-5 text-emerald-500" />
+                                                 class="flex h-10 w-10 items-center justify-center rounded-full bg-slate-50">
+                                                @if ($resolvedIcon)
+                                                    <x-dynamic-component :component="$resolvedIcon"
+                                                                         class="h-5 w-5"
+                                                                         @if ($iconColor) style="color: {{ $iconColor }}" @endif />
+                                                @elseif ($iconComponent)
+                                                    <span class="text-sm font-semibold text-slate-600"
+                                                          @if ($iconColor) style="color: {{ $iconColor }}" @endif>
+                                                        {{ $iconComponent }}
+                                                    </span>
+                                                @else
+                                                    <x-heroicon-o-check-badge class="h-5 w-5 text-primary-500" />
+                                                @endif
                                             </div>
                                             <div class="space-y-1">
-                                                <p class="text-sm font-semibold text-slate-900">{{ $feature['label'] }}
-                                                </p>
+                                                <p class="text-sm font-semibold text-slate-900">{{ $feature['label'] }}</p>
                                                 <p class="text-sm text-slate-600">{{ $feature['value'] }}</p>
                                             </div>
                                         </div>


### PR DESCRIPTION
## Summary
- aggregate product attribute data from associated variants so variant-managed features show up on the product page
- render stored attribute icons (with color support) instead of the placeholder checkmark in the product feature list

## Testing
- `php artisan test --filter=SingleProduct --stop-on-failure` *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdaf3fa788329b444e4651cc8be6a