### PR TITLE
Fix void arrow function return in ProductVariant resource

### DIFF
--- a/app/Filament/Resources/ProductVariantResource.php
+++ b/app/Filament/Resources/ProductVariantResource.php
@@ -280,7 +280,9 @@ final class ProductVariantResource extends Resource
                                                     ->preload()
                                                     ->reactive()
                                                     ->required()
-                                                    ->afterStateUpdated(fn (Set $set): void => $set('attribute_value_id', null)),
+                                                    ->afterStateUpdated(function (Set $set): void {
+                                                        $set('attribute_value_id', null);
+                                                    }),
                                                 Select::make('attribute_value_id')
                                                     ->label(__('product_variants.fields.attribute_value'))
                                                     ->options(function (Get $get) {


### PR DESCRIPTION
## Summary
- replace the void arrow callback on the attribute selector with a standard closure to avoid returning a value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfdd20cbbc83298601ac6d71b6557e