### PR TITLE
Fix product add-to-cart handling and add coverage

### DIFF
--- a/app/Filament/Resources/ProductVariantResource.php
+++ b/app/Filament/Resources/ProductVariantResource.php
@@ -280,7 +280,9 @@ final class ProductVariantResource extends Resource
                                                     ->preload()
                                                     ->reactive()
                                                     ->required()
-                                                    ->afterStateUpdated(fn (Set $set): void => $set('attribute_value_id', null)),
+                                                    ->afterStateUpdated(function (Set $set): void {
+                                                        $set('attribute_value_id', null);
+                                                    }),
                                                 Select::make('attribute_value_id')
                                                     ->label(__('product_variants.fields.attribute_value'))
                                                     ->options(function (Get $get) {

--- a/app/Livewire/Components/ProductCardExtended.php
+++ b/app/Livewire/Components/ProductCardExtended.php
@@ -56,7 +56,7 @@ final class ProductCardExtended extends Component
      */
     public function addToCart(): void
     {
-        $this->dispatch('add-to-cart', ['product_id' => $this->product->id, 'quantity' => 1]);
+        $this->dispatch('add-to-cart', productId: $this->product->id, quantity: 1);
         // Track analytics
         AnalyticsEvent::track('add_to_cart', ['product_id' => $this->product->id, 'product_name' => $this->product->name, 'product_price' => $this->product->price]);
         $this->dispatch('notify', ['type' => 'success', 'message' => __('translations.product_added_to_cart', ['name' => $this->product->name])]);

--- a/app/Livewire/ProductVariantSelector.php
+++ b/app/Livewire/ProductVariantSelector.php
@@ -260,10 +260,12 @@ final class ProductVariantSelector extends Component
         $this->recordAddToCart();
 
         // Dispatch event to add to cart
-        $this->dispatch('add-to-cart', [
-            'variant_id' => $this->selectedVariant->id,
-            'quantity' => $this->quantity,
-        ]);
+        $this->dispatch(
+            'add-to-cart',
+            productId: (int) $this->product->getKey(),
+            quantity: $this->quantity,
+            variantId: (int) $this->selectedVariant->getKey()
+        );
 
         $this->dispatch('show-success', message: __('product_variants.messages.added_to_cart'));
     }

--- a/app/Livewire/Shared/ShoppingCart.php
+++ b/app/Livewire/Shared/ShoppingCart.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Shared;
 
 use App\Models\CartItem;
 use App\Models\Product;
+use App\Models\ProductVariant;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Session;
 use Livewire\Attributes\On;
@@ -34,19 +35,93 @@ final class ShoppingCart extends Component
      * Handle addToCart functionality with proper error handling.
      */
     #[On('add-to-cart')]
-    public function addToCart(int $productId, int $quantity = 1): void
+    public function addToCart(int $productId, int $quantity = 1, ?int $variantId = null): void
     {
         $product = Product::findOrFail($productId);
+        $variant = null;
+
+        if ($variantId !== null) {
+            $variant = ProductVariant::query()
+                ->where('product_id', $productId)
+                ->findOrFail($variantId);
+        }
+
         $sessionId = Session::getId();
-        $cartItem = CartItem::where('session_id', $sessionId)->where('product_id', $productId)->first();
+        $unitPrice = $variant
+            ? (float) $variant->getCurrentPrice()
+            : (float) ($product->sale_price ?? $product->price);
+
+        $cartItemQuery = CartItem::query()
+            ->where('session_id', $sessionId)
+            ->where('product_id', $productId);
+
+        if ($variant) {
+            $cartItemQuery->where('variant_id', $variant->id);
+        } else {
+            $cartItemQuery->whereNull('variant_id');
+        }
+
+        $cartItem = $cartItemQuery->first();
+
         if ($cartItem) {
             $newQuantity = $cartItem->quantity + $quantity;
-            $unitPrice = (float) ($cartItem->unit_price ?? $product->sale_price ?? $product->price);
-            $cartItem->update(['quantity' => $newQuantity, 'unit_price' => $unitPrice, 'total_price' => round($unitPrice * $newQuantity, 2)]);
+
+            $cartItem->update([
+                'quantity' => $newQuantity,
+                'unit_price' => $unitPrice,
+                'price' => $unitPrice,
+                'total_price' => round($unitPrice * $newQuantity, 2),
+            ]);
         } else {
-            $unitPrice = (float) ($product->sale_price ?? $product->price);
-            CartItem::create(['session_id' => $sessionId, 'user_id' => auth()->id(), 'product_id' => $productId, 'quantity' => $quantity, 'unit_price' => $unitPrice, 'total_price' => round($unitPrice * $quantity, 2), 'product_snapshot' => ['name' => $product->name, 'price' => $unitPrice, 'sku' => $product->sku ?? null]]);
+            $variantAttributes = [];
+            $snapshotName = $product->name;
+
+            if ($variant) {
+                $snapshotName = $variant->name ?? $product->name;
+
+                $attributeValues = $variant->attributes()->with('attribute')->get();
+
+                if ($attributeValues->isNotEmpty()) {
+                    $variantAttributes = $attributeValues
+                        ->mapWithKeys(fn($value): array => [
+                            $value->attribute->name => $value->value,
+                        ])
+                        ->toArray();
+
+                    $snapshotName .= ' ('.collect($variantAttributes)
+                        ->map(fn($value, $key) => sprintf('%s: %s', $key, $value))
+                        ->implode(', ').')';
+                }
+            }
+
+            $productSnapshot = [
+                'name' => $snapshotName,
+                'price' => $unitPrice,
+                'sku' => $variant?->sku ?? $product->sku ?? null,
+            ];
+
+            if ($variant) {
+                $productSnapshot['variant_id'] = $variant->id;
+
+                if (! empty($variantAttributes)) {
+                    $productSnapshot['variant_attributes'] = $variantAttributes;
+                }
+            }
+
+            CartItem::create([
+                'session_id' => $sessionId,
+                'user_id' => auth()->id(),
+                'product_id' => $productId,
+                'variant_id' => $variant?->id,
+                'product_variant_id' => $variant?->id,
+                'quantity' => $quantity,
+                'unit_price' => $unitPrice,
+                'total_price' => round($unitPrice * $quantity, 2),
+                'price' => $unitPrice,
+                'product_snapshot' => $productSnapshot,
+            ]);
         }
+
         $this->dispatch('cart-updated');
     }
 

--- a/tests/Feature/Livewire/ShoppingCartTest.php
+++ b/tests/Feature/Livewire/ShoppingCartTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\Shared\ShoppingCart;
+use App\Models\CartItem;
+use App\Models\Product;
+use App\Models\ProductVariant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+final class ShoppingCartTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_adds_simple_product_to_cart(): void
+    {
+        $product = Product::factory()->create([
+            'price' => 199.00,
+            'sale_price' => null,
+            'status' => 'published',
+            'is_visible' => true,
+            'is_enabled' => true,
+            'published_at' => now()->subDay(),
+        ]);
+
+        session()->start();
+
+        Livewire::test(ShoppingCart::class)
+            ->call('addToCart', $product->id, 2);
+
+        $cartItem = CartItem::query()->withoutGlobalScopes()->first();
+
+        $this->assertNotNull($cartItem);
+        $this->assertSame($product->id, $cartItem->product_id);
+        $this->assertNull($cartItem->variant_id);
+        $this->assertSame(2, $cartItem->quantity);
+        $this->assertSame((float) $product->price, (float) $cartItem->unit_price);
+        $this->assertSame((float) $product->price, (float) $cartItem->price);
+    }
+
+    public function test_it_adds_variant_to_cart_with_variant_pricing(): void
+    {
+        $product = Product::factory()->create([
+            'type' => 'variable',
+            'price' => 249.00,
+            'sale_price' => null,
+            'status' => 'published',
+            'is_visible' => true,
+            'is_enabled' => true,
+            'published_at' => now()->subDay(),
+        ]);
+
+        $variant = ProductVariant::factory()
+            ->for($product)
+            ->create([
+                'price' => 179.45,
+                'promotional_price' => 149.99,
+                'is_on_sale' => true,
+                'sale_start_date' => now()->subDay(),
+                'sale_end_date' => now()->addDay(),
+                'is_default_variant' => true,
+                'track_inventory' => false,
+                'is_enabled' => true,
+            ]);
+
+        session()->start();
+
+        Livewire::test(ShoppingCart::class)
+            ->call('addToCart', $product->id, 3, $variant->id);
+
+        $cartItem = CartItem::query()->withoutGlobalScopes()->where('variant_id', $variant->id)->first();
+
+        $this->assertNotNull($cartItem);
+        $this->assertSame($product->id, $cartItem->product_id);
+        $this->assertSame($variant->id, $cartItem->variant_id);
+        $this->assertSame(3, $cartItem->quantity);
+        $this->assertSame((float) $variant->getCurrentPrice(), (float) $cartItem->unit_price);
+        $this->assertSame((float) $variant->getCurrentPrice(), (float) $cartItem->price);
+        $this->assertIsArray($cartItem->product_snapshot);
+        $this->assertSame($variant->id, $cartItem->product_snapshot['variant_id'] ?? null);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize add-to-cart event payloads so Livewire components always send named parameters
- allow the shared shopping cart component to handle variant-aware cart additions and improve its product snapshot data
- fix a Filament form callback that returned a value from a void arrow function and add Livewire feature tests for simple and variant cart additions

## Testing
- ./vendor/bin/pest --filter=ShoppingCartTest


------
https://chatgpt.com/codex/tasks/task_e_68dfdc25932c832981250552983eb92b