### PR TITLE
Display stock summary in product refactor block

### DIFF
--- a/resources/views/livewire/pages/single-product.blade.php
+++ b/resources/views/livewire/pages/single-product.blade.php
@@ -468,6 +468,16 @@
                                     {{ __('product_page.quality_guarantee') }}
                                 </p>
                             </div>
+                            <div class="flex flex-wrap items-center gap-3 text-sm font-medium text-slate-600">
+                                <span class="inline-flex items-center gap-1">
+                                    <span class="text-slate-500">{{ __('translations.reserved') }}:</span>
+                                    <span class="text-slate-900">{{ \Illuminate\Support\Number::format((float) $product->reservedQuantity()) }}</span>
+                                </span>
+                                <span class="inline-flex items-center gap-1">
+                                    <span class="text-slate-500">{{ __('translations.available') }}:</span>
+                                    <span class="text-slate-900">{{ \Illuminate\Support\Number::format((float) $product->availableQuantity()) }}</span>
+                                </span>
+                            </div>
                             <div class="variant-selector-card">
                                 <livewire:components.variants-selector :product="$product" />
                             </div>


### PR DESCRIPTION
## Summary
- show reserved and available inventory counts alongside the product brand and price sidebar
- format the counts with locale-aware numbers and existing translations in the product refactor block

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfde564ac8832990220048a0cadf86