### PR TITLE
Fix TypeError when rounding average product ratings

### DIFF
--- a/app/Livewire/Components/ProductReviews.php
+++ b/app/Livewire/Components/ProductReviews.php
@@ -98,6 +98,6 @@ final class ProductReviews extends Component
         $averageRating = Review::where('product_id', $this->product->id)->approved()->avg('rating');
         $ratingDistribution = Review::where('product_id', $this->product->id)->approved()->selectRaw('rating, COUNT(*) as count')->groupBy('rating')->orderBy('rating', 'desc')->pluck('count', 'rating')->toArray();
 
-        return view('livewire.components.product-reviews', ['reviews' => $reviews, 'averageRating' => round($averageRating, 1), 'totalReviews' => $reviews->total(), 'ratingDistribution' => $ratingDistribution]);
+        return view('livewire.components.product-reviews', ['reviews' => $reviews, 'averageRating' => round((float) $averageRating, 1), 'totalReviews' => $reviews->total(), 'ratingDistribution' => $ratingDistribution]);
     }
 }


### PR DESCRIPTION
## Summary
- cast the aggregated average rating to a float before rounding so PHP 8.3 no longer throws a TypeError when reviews are averaged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe0d73cb4832980fc64653ee33e73