### PR TITLE
Refactor product breadcrumb generation

### DIFF
--- a/app/Support/Breadcrumbs/ProductBreadcrumbBuilder.php
+++ b/app/Support/Breadcrumbs/ProductBreadcrumbBuilder.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Breadcrumbs;
+
+use App\Models\Category;
+use App\Models\Product;
+use Illuminate\Support\Collection;
+
+final class ProductBreadcrumbBuilder
+{
+    /**
+     * Build breadcrumb items for rendering within the UI.
+     *
+     * @return array<int, array{label: string, url: string|null}>
+     */
+    public static function display(Product $product): array
+    {
+        return self::baseItems($product)->all();
+    }
+
+    /**
+     * Build breadcrumb items formatted for Schema.org `BreadcrumbList` JSON-LD.
+     *
+     * @return array<int, array{'@type': string, position: int, name: string, item: string|null}>
+     */
+    public static function schema(Product $product): array
+    {
+        return self::schemaFromDisplay(self::display($product));
+    }
+
+    /**
+     * Convert UI breadcrumb items into Schema.org list items.
+     *
+     * @param  array<int, array{label: string, url: string|null}>  $displayItems
+     * @return array<int, array{'@type': string, position: int, name: string, item: string|null}>
+     */
+    public static function schemaFromDisplay(array $displayItems): array
+    {
+        return collect($displayItems)
+            ->values()
+            ->map(function (array $item, int $index) {
+                return [
+                    '@type' => 'ListItem',
+                    'position' => $index + 1,
+                    'name' => $item['label'],
+                    'item' => $item['url'],
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection<int, array{label: string, url: string|null}>
+     */
+    private static function baseItems(Product $product): Collection
+    {
+        $items = collect();
+
+        $items->push([
+            'label' => __('breadcrumbs.department'),
+            'url' => url('/'),
+        ]);
+
+        if ($category = self::resolvePrimaryCategory($product)) {
+            $items->push([
+                'label' => $category->trans('name') ?? $category->name,
+                'url' => self::resolveCategoryUrl($category),
+            ]);
+        }
+
+        $items->push([
+            'label' => $product->trans('name') ?? $product->name,
+            'url' => self::resolveProductUrl($product),
+        ]);
+
+        return $items
+            ->filter(fn (array $item) => filled($item['label']))
+            ->values();
+    }
+
+    private static function resolveProductUrl(Product $product): ?string
+    {
+        $slug = $product->trans('slug') ?? $product->slug;
+
+        return $slug ? route('product.show', $slug) : null;
+    }
+
+    private static function resolvePrimaryCategory(Product $product): ?Category
+    {
+        if ($product->relationLoaded('categories')) {
+            return $product->categories->first();
+        }
+
+        if (method_exists($product, 'categories')) {
+            return $product->categories()->first();
+        }
+
+        return null;
+    }
+
+    private static function resolveCategoryUrl(Category $category): ?string
+    {
+        $slug = method_exists($category, 'trans')
+            ? ($category->trans('slug') ?? $category->slug ?? null)
+            : ($category->slug ?? null);
+
+        if (! $slug) {
+            return null;
+        }
+
+        return route('localized.categories.show', [
+            'locale' => app()->getLocale(),
+            'category' => $slug,
+        ]);
+    }
+}

--- a/resources/views/livewire/pages/single-product-v1.blade.php
+++ b/resources/views/livewire/pages/single-product-v1.blade.php
@@ -13,33 +13,43 @@
             :preload-image="(string) ($ogImage ?: '')" />
 @endsection
 
+@php
+    $breadcrumbDisplayItems = \App\Support\Breadcrumbs\ProductBreadcrumbBuilder::display($product);
+    $breadcrumbSchemaItems = \App\Support\Breadcrumbs\ProductBreadcrumbBuilder::schemaFromDisplay($breadcrumbDisplayItems);
+@endphp
+
 <div class="bg-white">
     <div class="pb-16 pt-6 sm:pb-24">
         <nav aria-label="Breadcrumb" class="mx-auto max-w-8xl px-4">
             <ol role="list" class="flex items-center space-x-4">
-                <li>
-                    <div class="flex items-center">
-                        <a href="#"
-                           class="mr-4 text-sm font-medium text-gray-900">{{ __('breadcrumbs.department') }}</a>
-                        <svg viewBox="0 0 6 20" aria-hidden="true" class="h-5 w-auto text-gray-300">
-                            <path d="M4.878 4.34H3.551L.27 16.532h1.327l3.281-12.19z" fill="currentColor" />
-                        </svg>
-                    </div>
-                </li>
-                <li>
-                    <div class="flex items-center">
-                        <a href="#"
-                           class="mr-4 text-sm font-medium text-gray-900">{{ __('breadcrumbs.category') }}</a>
-                        <svg viewBox="0 0 6 20" aria-hidden="true" class="h-5 w-auto text-gray-300">
-                            <path d="M4.878 4.34H3.551L.27 16.532h1.327l3.281-12.19z" fill="currentColor" />
-                        </svg>
-                    </div>
-                </li>
-                <li class="text-sm">
-                    <span aria-current="page" class="font-medium text-gray-500">
-                        {{ $product->name }}
-                    </span>
-                </li>
+                @php($lastBreadcrumbIndex = count($breadcrumbDisplayItems) - 1)
+                @foreach($breadcrumbDisplayItems as $index => $breadcrumb)
+                    <li @class(['text-sm' => $index === $lastBreadcrumbIndex])>
+                        <div class="flex items-center">
+                            @if($index === $lastBreadcrumbIndex)
+                                <span aria-current="page" class="font-medium text-gray-500">
+                                    {{ $breadcrumb['label'] }}
+                                </span>
+                            @else
+                                @if($breadcrumb['url'])
+                                    <a href="{{ $breadcrumb['url'] }}" class="mr-4 text-sm font-medium text-gray-900">
+                                        {{ $breadcrumb['label'] }}
+                                    </a>
+                                @else
+                                    <span class="mr-4 text-sm font-medium text-gray-900">
+                                        {{ $breadcrumb['label'] }}
+                                    </span>
+                                @endif
+                            @endif
+
+                            @if($index !== $lastBreadcrumbIndex)
+                                <svg viewBox="0 0 6 20" aria-hidden="true" class="h-5 w-auto text-gray-300">
+                                    <path d="M4.878 4.34H3.551L.27 16.532h1.327l3.281-12.19z" fill="currentColor" />
+                                </svg>
+                            @endif
+                        </div>
+                    </li>
+                @endforeach
             </ol>
         </nav>
         <x-container class="mt-8 max-w-2xl">
@@ -181,40 +191,6 @@
             }
         }
 
-        // Basic breadcrumb items (department -> category -> product). Replace placeholders if real data exists.
-        $breadcrumbItems = [
-            [
-                '@type' => 'ListItem',
-                'position' => 1,
-                'name' => __('breadcrumbs.department'),
-                'item' => url('/'),
-            ],
-        ];
-        $position = 2;
-        // If a category relation exists, include it
-        try {
-            if (isset($product->categories) && $product->categories->first()) {
-                $cat = $product->categories->first();
-                $breadcrumbItems[] = [
-                    '@type' => 'ListItem',
-                    'position' => $position++,
-                    'name' => $cat->trans('name') ?? $cat->name,
-                    'item' => route('localized.categories.show', [
-                        'locale' => app()->getLocale(),
-                        'category' => $cat->trans('slug') ?? $cat->slug,
-                    ]),
-                ];
-            }
-        } catch (Throwable $e) {
-            // ignore if relation missing
-        }
-        $breadcrumbItems[] = [
-            '@type' => 'ListItem',
-            'position' => $position,
-            'name' => $product->trans('name') ?? $product->name,
-            'item' => $productUrl,
-        ];
-
         $productSchema = [
             '@context' => 'https://schema.org',
             '@type' => 'Product',
@@ -239,6 +215,6 @@
         {!! json_encode($productSchema, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) !!}
     </script>
     <script type="application/ld+json">
-        {!! json_encode(['@context' => 'https://schema.org', '@type' => 'BreadcrumbList', 'itemListElement' => $breadcrumbItems], JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) !!}
+        {!! json_encode(['@context' => 'https://schema.org', '@type' => 'BreadcrumbList', 'itemListElement' => $breadcrumbSchemaItems], JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) !!}
     </script>
 @endpush


### PR DESCRIPTION
## Summary
- extract breadcrumb construction into a reusable `ProductBreadcrumbBuilder`
- render the product page breadcrumb trail dynamically using the builder output
- reuse the same breadcrumb data for Schema.org JSON-LD to keep the UI and structured data in sync

## Testing
- php -l app/Support/Breadcrumbs/ProductBreadcrumbBuilder.php

------
https://chatgpt.com/codex/tasks/task_e_68dfe2ddefac8329b55b96f51cc289f5