### PR TITLE
Simplify image regeneration seeding flow

### DIFF
--- a/app/Console/Commands/OptimizeAllImages.php
+++ b/app/Console/Commands/OptimizeAllImages.php
@@ -82,8 +82,8 @@ final class OptimizeAllImages extends Command
         $this->info('🔄 Regenerating all images from scratch...');
 
         // Clear all existing media
-        $this->warn('⚠️  This will delete all existing images and regenerate them!');
-        if (! $this->confirm('Are you sure you want to continue?')) {
+        $this->warn('⚠️  This will reset the database using migrate:fresh --seed and regenerate all images!');
+        if (! $this->confirm('Are you sure you want to reset the database and reseed all data?')) {
             $this->info('Operation cancelled.');
 
             return;
@@ -92,22 +92,12 @@ final class OptimizeAllImages extends Command
         // Delete all media files
         Media::query()->delete();
 
-        // Run seeders to regenerate images
-        $this->call('db:seed', [
-            '--class' => 'RealProductImagesSeeder',
+        // Reset database and run all default seeders in a single command
+        $this->call('migrate:fresh', [
+            '--seed' => true,
         ]);
 
-        $this->call('db:seed', [
-            '--class' => 'CategorySeeder',
-        ]);
-
-        $this->call('db:seed', [
-            '--class' => 'BrandSeeder',
-        ]);
-
-        $this->call('db:seed', [
-            '--class' => 'CollectionSeeder',
-        ]);
+        $this->info('✅ Database reseeded and images regenerated.');
     }
 
     private function optimizeAllImages(): void

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -40,6 +40,8 @@ class DatabaseSeeder extends Seeder
             AttributeValueSeeder::class,
             // High‑performance product seeding with attributes, relations, translations, and local images
             TurboEcommerceSeeder::class,
+            // Replace placeholder assets with generated WebP images
+            RealProductImagesSeeder::class,
             LocationSeeder::class,
             InventorySeeder::class,
             VariantInventorySeeder::class,


### PR DESCRIPTION
## Summary
- update the OptimizeAllImages regenerate workflow to rely on `php artisan migrate:fresh --seed`
- include `RealProductImagesSeeder` in the default `DatabaseSeeder` so the fresh seed covers image assets

## Testing
- php -l app/Console/Commands/OptimizeAllImages.php
- php -l database/seeders/DatabaseSeeder.php

------
https://chatgpt.com/codex/tasks/task_e_68dfe60125f88329ba1b0c34d69b3989