### PR TITLE
Add project-wide AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# Project Automation & Filament Standards
+
+This repository mixes Laravel 11 and Filament v4 code. Use the following guardrails whenever you touch files within this repo (scope: entire project).
+
+## Workflow Expectations
+
+- After editing PHP or Blade files, run the quick quality loop before committing:
+  1. `php -l <file>` to ensure syntax is valid.
+  2. `vendor/bin/pint <file>` to fix style issues (run without `--test` so it can auto-fix).
+  3. `vendor/bin/phpstan analyse <file> -c phpstan.neon --memory-limit=1G --no-progress` for static analysis.
+  4. `vendor/bin/rector process <file> --ansi --no-progress-bar` to apply automated refactors where appropriate.
+- When Blade templates change, refresh the cache with `php artisan view:clear` followed by `php artisan view:cache`.
+- If changes touch application logic, run the most relevant `php artisan test --filter=...` target (or the full test suite when in doubt).
+- When configuration or routes change, refresh caches via:
+  ```bash
+  php artisan config:clear && php artisan route:clear
+  php artisan config:cache && php artisan route:cache
+  ```
+- Prefer documenting any outstanding warnings or skipped checks directly in commit messages or PR descriptions.
+
+## Filament v4 Resource Rules
+
+For every file under `app/Filament/**`:
+
+- Import `Filament\Forms\Form` and `Filament\Tables\Table` when the resource defines `form()` or `table()`.
+- Remove any `use App\Filament\Resources\Schema;` import—it conflicts with Filament v4 conventions.
+- Ensure the method signatures match v4 expectations:
+  ```php
+  public static function form(Form $form): Form
+  public static function table(Table $table): Table
+  ```
+- Inside `form()` bodies, use the `$form` variable consistently after updating the signature.
+- Standardize the `$navigationIcon` property to be untyped with the docblock:
+  ```php
+  /** @var string|\BackedEnum|null */
+  protected static $navigationIcon = 'heroicon-o-document-text';
+  ```
+  (Preserve the existing icon value when normalizing the property.)
+- If a class named `App\Filament\Resources\Schema` exists, rename it to avoid collisions and update any imports accordingly.
+
+## Testing & Data Discipline
+
+- Keep database seeds multilingual (Lithuanian default, with English equivalents) and ensure currency formatting uses euros via `Number::currency` when rendering monetary values.
+- When you add or modify Filament resources or Livewire components, provide or update Pest tests that cover CRUD operations, authorization, and localization behavior.
+- Use factories with descriptive data to keep tests clear.
+
+## Coding Standards
+
+- Follow PSR-12, enable `declare(strict_types=1);`, and lean on constructor property promotion, typed properties/returns, and Laravel helpers where it improves clarity.
+- Favor Tailwind utility classes in Blade templates and keep business logic inside view models or dedicated classes instead of views.
+- Stick to SOLID design principles: encapsulate domain logic in services/repositories as needed, and avoid duplicating logic across the admin/front-end layers.
+
+## Tooling Notes
+
+- Use `php artisan boost:mcp` if you need to access the internal MCP utilities for searching docs or running targeted fixes.
+- Keep change descriptions focused and concise; avoid generating additional documentation files unless requested.
+- Git operations (add/commit/push) are allowed unless a higher-priority instruction forbids them.
+
+## Memory Bank Utilities
+
+- The `memory-bank/` directory contains support files (`tasks.md`, `activeContext.md`, etc.). Ensure these remain consistent; do not delete or repurpose them without stakeholder approval.
+


### PR DESCRIPTION
## Summary
- add a project-level `AGENTS.md` with workflow, testing, and Filament v4 resource guidance

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1aa33ea948329bc453dcfe4d95f9d