### PR TITLE
Add Filament form alias fallback

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -43,6 +43,10 @@ class AppServiceProvider extends ServiceProvider
         // Register Livewire components
         Livewire::component('live-notification-feed', LiveNotificationFeed::class);
 
+        if (! class_exists(\Filament\Forms\Form::class) && class_exists(\Filament\Schemas\Schema::class)) {
+            class_alias(\Filament\Schemas\Schema::class, \Filament\Forms\Form::class);
+        }
+
         // Aliases for Filament resource Livewire components used in tests
         if ($this->app->environment('testing')) {
             Livewire::component('filament.admin.resources.product-comparisons.index', \App\Filament\Resources\ProductComparisonResource\Pages\ListProductComparisons::class);


### PR DESCRIPTION
## Summary
- add a runtime alias from `Filament\Schemas\Schema` to `Filament\Forms\Form` when the new class is not yet available so v4 resources can load

## Testing
- php -l app/Providers/AppServiceProvider.php
- vendor/bin/pint app/Providers/AppServiceProvider.php *(fails: vendor directory not available in environment)*
- vendor/bin/phpstan analyse app/Providers/AppServiceProvider.php -c phpstan.neon --memory-limit=1G --no-progress *(fails: vendor directory not available in environment)*
- vendor/bin/rector process app/Providers/AppServiceProvider.php --ansi --no-progress-bar *(fails: vendor directory not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b0ca77588329984b4e0f266094e7