### PR TITLE
Add Filament form fallback alias

### DIFF
--- a/app/Support/filament_compat.php
+++ b/app/Support/filament_compat.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+if (! class_exists(\Filament\Forms\Form::class) && class_exists(\Filament\Schemas\Schema::class)) {
+    class_alias(\Filament\Schemas\Schema::class, \Filament\Forms\Form::class);
+}

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
             "Database\\Seeders\\Cities\\": "database/seeders/cities/"
         },
         "files": [
-            "app/helpers.php"
+            "app/helpers.php",
+            "app/Support/filament_compat.php"
         ]
     },
     "autoload-dev": {


### PR DESCRIPTION
## Summary
- provide a runtime alias for `Filament\Forms\Form` when the v4 class is unavailable so resources stay compatible
- register the compatibility shim in Composer autoload files so it is loaded automatically

## Testing
- php -l app/Support/filament_compat.php
- vendor/bin/pint app/Support/filament_compat.php *(fails: vendor binaries not installed in container)*
- vendor/bin/phpstan analyse app/Support/filament_compat.php -c phpstan.neon --memory-limit=1G --no-progress *(fails: vendor binaries not installed in container)*
- vendor/bin/rector process app/Support/filament_compat.php --ansi --no-progress-bar *(fails: vendor binaries not installed in container)*
- composer dump-autoload *(fails: framework bootstrap classes unavailable without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b0ca77588329984b4e0f266094e7