### PR TITLE
Normalize EmailMarketingPage navigation icon property

### DIFF
--- a/app/Filament/Pages/EmailMarketingPage.php
+++ b/app/Filament/Pages/EmailMarketingPage.php
@@ -10,8 +10,8 @@ use Filament\Pages\Page;
 
 final class EmailMarketingPage extends Page
 {
-    // /** @var BackedEnum|string|null */
-    //     protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-envelope-open';
+    /** @var string|\BackedEnum|null */
+    protected static $navigationIcon = 'heroicon-o-envelope-open';
 
     protected string $view = 'filament.pages.email-marketing-page';
 


### PR DESCRIPTION
## Summary
- standardize EmailMarketingPage's navigation icon to the untyped property format with the required docblock

## Testing
- php -l app/Filament/Pages/EmailMarketingPage.php

------
https://chatgpt.com/codex/tasks/task_e_68e1b0ca77588329984b4e0f266094e7