### PR TITLE
Add compatibility alias for Filament Tables builder

### DIFF
--- a/app/Support/filament_compat.php
+++ b/app/Support/filament_compat.php
@@ -5,3 +5,7 @@ declare(strict_types=1);
 if (! class_exists(\Filament\Forms\Form::class) && class_exists(\Filament\Schemas\Schema::class)) {
     class_alias(\Filament\Schemas\Schema::class, \Filament\Forms\Form::class);
 }
+
+if (! class_exists(\Filament\Tables\Table::class) && class_exists(\Filament\Resources\Table::class)) {
+    class_alias(\Filament\Resources\Table::class, \Filament\Tables\Table::class);
+}


### PR DESCRIPTION
## Summary
- ensure the Filament compatibility shim also aliases `Filament\Resources\Table` to `Filament\Tables\Table` when the new class is unavailable

## Testing
- php -l app/Support/filament_compat.php

------
https://chatgpt.com/codex/tasks/task_e_68e1b55d0bd083298e5538c778fe1b2b