### PR TITLE
Ensure Filament compatibility shim loads during bootstrap

### DIFF
--- a/app/Support/filament_compat.php
+++ b/app/Support/filament_compat.php
@@ -5,3 +5,7 @@ declare(strict_types=1);
 if (! class_exists(\Filament\Forms\Form::class) && class_exists(\Filament\Schemas\Schema::class)) {
     class_alias(\Filament\Schemas\Schema::class, \Filament\Forms\Form::class);
 }
+
+if (! class_exists(\Filament\Tables\Table::class) && class_exists(\Filament\Resources\Table::class)) {
+    class_alias(\Filament\Resources\Table::class, \Filament\Tables\Table::class);
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,6 +5,8 @@ use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 
+require_once __DIR__ . '/../app/Support/filament_compat.php';
+
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__ . '/../routes/web.php',


### PR DESCRIPTION
## Summary
- require the Filament compatibility shim during Laravel bootstrap so legacy Schema-based APIs are always aliased

## Testing
- php -l bootstrap/app.php

------
https://chatgpt.com/codex/tasks/task_e_68e1b55d0bd083298e5538c778fe1b2b