### PR TITLE
Add runtime alias to resolve AddressResource form dependency

### DIFF
--- a/app/Filament/Resources/AddressResource.php
+++ b/app/Filament/Resources/AddressResource.php
@@ -37,6 +37,11 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 
 use Filament\Forms\Form;
+use Filament\Schemas\Schema;
+
+if (! class_exists(Form::class) && class_exists(Schema::class)) {
+    class_alias(Schema::class, Form::class);
+}
 
 /**
  * AddressResource


### PR DESCRIPTION
## Summary
- add a runtime class alias so the Filament\Forms\Form type used by AddressResource resolves when only Filament\Schemas\Schema is available

## Testing
- php -l app/Filament/Resources/AddressResource.php

------
https://chatgpt.com/codex/tasks/task_e_68e209ae30e08329aee7eec2b556f43c