### PR TITLE
Add artisan command to detect feature tests missing RefreshDatabase

### DIFF
--- a/app/Console/Commands/CheckRefreshDatabaseCommand.php
+++ b/app/Console/Commands/CheckRefreshDatabaseCommand.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+final class CheckRefreshDatabaseCommand extends Command
+{
+    /**
+     * @var array<string, string>
+     */
+    private const MUTATION_PATTERNS = [
+        '::factory(' => '/::factory\s*\(/',
+        '->factory(' => '/->factory\s*\(/',
+        '->seed(' => '/->seed\s*\(/',
+        'HTTP verb' => '/->\s*(?:post|put|patch|delete)(?:Json)?\s*\(/i',
+        'HTTP call verb' => "/->\s*call\s*\(\s*['\"]\s*(?:post|put|patch|delete)/i",
+        'artisan db:seed' => "/->\s*artisan\s*\(\s*['\"]db:seed/i",
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const DATABASE_REFRESH_TRAITS = [
+        'RefreshDatabase',
+        'DatabaseMigrations',
+        'DatabaseTransactions',
+        'DatabaseTruncation',
+    ];
+
+    /**
+     * @var string
+     */
+    protected $signature = 'tests:check-refresh-database
+        {path=tests/Feature : The directory to scan for feature tests}
+        {--fail-on-find : Exit with a non-zero status code when files are flagged}
+        {--include-all : List every file missing a database refresh trait, even without mutation indicators}
+        {--json : Output JSON for tooling integrations}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Find feature tests that might be creating database records without RefreshDatabase or similar traits.';
+
+    public function handle(): int
+    {
+        $directory = base_path($this->argument('path'));
+
+        if (! is_dir($directory)) {
+            $this->components->error(sprintf('The path [%s] is not a directory.', $directory));
+
+            return self::FAILURE;
+        }
+
+        $filesystem = new Filesystem;
+        $finder = (new Finder)
+            ->files()
+            ->in($directory)
+            ->name('*.php');
+
+        $flagged = [];
+        $missing = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($finder as $file) {
+            $contents = $filesystem->get($file->getRealPath());
+
+            if ($this->usesRefreshTrait($contents)) {
+                continue;
+            }
+
+            $indicators = $this->matchMutationIndicators($contents);
+            $relativePath = str_replace('\\', '/', $file->getRelativePathname());
+
+            if ($indicators !== []) {
+                $flagged[] = [
+                    'file' => $relativePath,
+                    'indicators' => $indicators,
+                ];
+
+                continue;
+            }
+
+            if ($this->option('include-all')) {
+                $missing[] = $relativePath;
+            }
+        }
+
+        if ($this->option('json')) {
+            $this->line((string) json_encode([
+                'flagged' => $flagged,
+                'missing' => $missing,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        } else {
+            if ($flagged === []) {
+                $this->components->info('No potential offenders were found.');
+            } else {
+                $this->components->warn('Potential database-mutating tests without refresh traits:');
+
+                foreach ($flagged as $result) {
+                    $this->line(sprintf(' - %s (%s)', $result['file'], implode(', ', $result['indicators'])));
+                }
+            }
+
+            if ($missing !== []) {
+                $this->newLine();
+                $this->components->warn('Files missing a refresh trait (no mutation indicators found):');
+
+                foreach ($missing as $file) {
+                    $this->line(sprintf(' - %s', $file));
+                }
+            }
+        }
+
+        if ($flagged !== [] && $this->option('fail-on-find')) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function usesRefreshTrait(string $contents): bool
+    {
+        foreach (self::DATABASE_REFRESH_TRAITS as $trait) {
+            if (str_contains($contents, $trait)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function matchMutationIndicators(string $contents): array
+    {
+        $indicators = [];
+
+        foreach (self::MUTATION_PATTERNS as $label => $pattern) {
+            if (preg_match($pattern, $contents) === 1) {
+                $indicators[] = $label;
+            }
+        }
+
+        return $indicators;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,6 +15,7 @@ final class Kernel extends ConsoleKernel
         \App\Console\Commands\CodeStyleWatchCommand::class,
         \App\Console\Commands\DemonstrateTimeoutCommand::class,
         \App\Console\Commands\GenerateReportsCommand::class,
+        \App\Console\Commands\CheckRefreshDatabaseCommand::class,
     ];
 
     protected function schedule(Schedule $schedule): void

--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,9 @@
         "rector": "vendor/bin/rector process --ansi",
         "blade:format": "php artisan view:clear && php artisan view:cache",
         "test": "php artisan test --parallel --recreate-databases --stop-on-failure",
+        "tests:check-refresh": [
+            "@php artisan tests:check-refresh-database --path=tests/Feature --fail-on-find"
+        ],
         "check": [
             "@lint:php",
             "@analyze",

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,6 +70,20 @@ tests/
 php artisan test
 ```
 
+### Scan for missing `RefreshDatabase`
+```bash
+php artisan tests:check-refresh-database --path=tests/Feature --fail-on-find
+```
+
+You can also run the Composer shortcut:
+
+```bash
+composer tests:check-refresh
+```
+
+The command surfaces feature tests that omit database refresh traits yet appear to create records (e.g., via factories or HTTP
+requests), mirroring the workflow described in [Laravel News](https://laravel-news.com/find-feature-tests-creating-database-records-without-refreshing-the-database-in-laravel).
+
 ### Run specific test categories
 ```bash
 # Admin tests


### PR DESCRIPTION
## Summary
- add a `tests:check-refresh-database` artisan command that scans feature tests for database-mutating heuristics when the `RefreshDatabase` trait is missing
- register the command with the console kernel, expose a `composer tests:check-refresh` shortcut, and document the workflow in the testing README referencing the Laravel News guidance

## Testing
- `php -l app/Console/Commands/CheckRefreshDatabaseCommand.php`
- `php -l app/Console/Kernel.php`
- `./vendor/bin/pint app/Console/Commands/CheckRefreshDatabaseCommand.php`
- `./vendor/bin/pint app/Console/Kernel.php`
- `./vendor/bin/phpstan analyse app/Console/Commands/CheckRefreshDatabaseCommand.php -c phpstan.neon --memory-limit=1G --no-progress -a /tmp/phpstan-filament-stub.php` *(fails: existing Filament resource navigationIcon type mismatch)*
- `./vendor/bin/phpstan analyse app/Console/Kernel.php -c phpstan.neon --memory-limit=1G --no-progress -a /tmp/phpstan-filament-stub.php` *(fails: existing Filament resource navigationIcon type mismatch)*
- `./vendor/bin/rector process app/Console/Commands/CheckRefreshDatabaseCommand.php --ansi --no-progress-bar` *(skipped: project lacks rector.php config)*
- `./vendor/bin/rector process app/Console/Kernel.php --ansi --no-progress-bar` *(skipped: project lacks rector.php config)*
- `php artisan tests:check-refresh-database --path=tests/Feature --include-all` *(fails: existing Filament resource navigationIcon type mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68e20dee77b48329b044ea6503b0b321