### PR TITLE
Add podcast embed support to news detail page

### DIFF
--- a/app/Filament/Resources/NewsResource.php
+++ b/app/Filament/Resources/NewsResource.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\NewsResource\RelationManagers;
 use App\Models\News;
 use BackedEnum;
 use Filament\Forms;
+use Filament\Forms\Form;
 use Filament\Infolists;
 use Filament\Resources\Resource;
 use Filament\Tables;
@@ -16,8 +17,6 @@ use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
-
-use Filament\Forms\Form;
 
 class NewsResource extends Resource
 {
@@ -93,6 +92,20 @@ class NewsResource extends Resource
                         ->maxLength(255),
                 ])
                 ->columns(1),
+            Forms\Components\Section::make(__('news.podcast.section_title'))
+                ->description(__('news.podcast.section_description'))
+                ->collapsible()
+                ->collapsed()
+                ->schema([
+                    Forms\Components\TextInput::make('meta_data.podcast_url')
+                        ->label(__('news.fields.podcast_url'))
+                        ->placeholder('https://share.transistor.fm/s/...')
+                        ->maxLength(2048)
+                        ->url()
+                        ->nullable()
+                        ->dehydrateStateUsing(static fn (?string $state): ?string => filled($state) ? trim($state) : null)
+                        ->helperText(__('news.podcast.field_help')),
+                ]),
             Forms\Components\Section::make('Categories & Tags')
                 ->schema([
                     Forms\Components\Select::make('categories')

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Str;
 
 /**
  * News
@@ -223,5 +224,90 @@ final class News extends Model
     public function getSeoDescriptionAttribute(): ?string
     {
         return $this->getTranslation('seo_description', app()->getLocale());
+    }
+
+    /**
+     * Retrieve a sanitized embed URL for the associated podcast episode.
+     */
+    public function getPodcastPlayerUrl(): ?string
+    {
+        $embedUrl = data_get($this->meta_data, 'podcast_embed_url');
+        if (is_string($embedUrl) && $embedUrl !== '') {
+            $normalized = $this->normalizePodcastUrl($embedUrl, true);
+            if ($normalized !== null) {
+                return $normalized;
+            }
+        }
+
+        $shareUrl = data_get($this->meta_data, 'podcast_url');
+        if (is_string($shareUrl) && $shareUrl !== '') {
+            return $this->normalizePodcastUrl($shareUrl, true);
+        }
+
+        return null;
+    }
+
+    /**
+     * Retrieve a sanitized share URL for the associated podcast episode.
+     */
+    public function getPodcastShareUrl(): ?string
+    {
+        $shareUrl = data_get($this->meta_data, 'podcast_url');
+        if (is_string($shareUrl) && $shareUrl !== '') {
+            $normalized = $this->normalizePodcastUrl($shareUrl, false);
+            if ($normalized !== null) {
+                return $normalized;
+            }
+        }
+
+        $embedUrl = data_get($this->meta_data, 'podcast_embed_url');
+        if (is_string($embedUrl) && $embedUrl !== '') {
+            return $this->normalizePodcastUrl($embedUrl, false);
+        }
+
+        return null;
+    }
+
+    /**
+     * Normalize supported podcast URLs while avoiding untrusted hosts.
+     */
+    private function normalizePodcastUrl(string $url, bool $preferEmbed): ?string
+    {
+        $trimmed = trim($url);
+        if ($trimmed === '' || filter_var($trimmed, FILTER_VALIDATE_URL) === false) {
+            return null;
+        }
+
+        $parsed = parse_url($trimmed);
+        if ($parsed === false || ! isset($parsed['host'])) {
+            return null;
+        }
+
+        $host = strtolower($parsed['host']);
+        if (! Str::contains($host, 'transistor.fm')) {
+            return null;
+        }
+
+        $path = $parsed['path'] ?? '';
+        $path = '/'.ltrim($path, '/');
+        if ($path === '/') {
+            return null;
+        }
+
+        if ($preferEmbed) {
+            if (Str::startsWith($path, '/s/')) {
+                $path = Str::replaceFirst('/s/', '/e/', $path);
+            } elseif (! Str::startsWith($path, '/e/')) {
+                return null;
+            }
+        } else {
+            if (Str::startsWith($path, '/e/')) {
+                $path = Str::replaceFirst('/e/', '/s/', $path);
+            } elseif (! Str::startsWith($path, '/s/')) {
+                return null;
+            }
+        }
+
+        return 'https://share.transistor.fm'.$path;
     }
 }

--- a/lang/en/news.php
+++ b/lang/en/news.php
@@ -39,6 +39,13 @@ return [
     'newsletter_subscribe' => 'Subscribe',
     'newsletter_success' => 'Successfully subscribed to newsletter',
     'newsletter_error' => 'Error subscribing to newsletter',
+    'podcast' => [
+        'section_title' => 'Listen to the podcast',
+        'section_description' => 'Tune into the related Laravel News Podcast episode for more insights.',
+        'listen_cta' => 'Open episode on Transistor',
+        'embed_title' => 'Laravel News Podcast player',
+        'field_help' => 'Use the public Transistor share link (https://share.transistor.fm/s/...) and the player will be embedded automatically.',
+    ],
     // Admin form fields
     'basic_information' => 'Basic Information',
     'media' => 'Media',
@@ -122,6 +129,7 @@ return [
         'meta_title' => 'Meta Title',
         'meta_description' => 'Meta Description',
         'meta_keywords' => 'Meta Keywords',
+        'podcast_url' => 'Podcast share URL',
         'categories' => 'Categories',
         'tags' => 'Tags',
         'view_count' => 'View Count',

--- a/lang/lt/news.php
+++ b/lang/lt/news.php
@@ -39,6 +39,13 @@ return [
     'newsletter_subscribe' => 'Prenumeruoti',
     'newsletter_success' => 'Sėkmingai prenumeruota naujienlaiškiui',
     'newsletter_error' => 'Įvyko klaida prenumeruojant naujienlaiškiui',
+    'podcast' => [
+        'section_title' => 'Klausykite tinklalaidės',
+        'section_description' => 'Sužinokite daugiau iš susijusio Laravel News tinklalaidės epizodo.',
+        'listen_cta' => 'Atverti epizodą Transistor platformoje',
+        'embed_title' => 'Laravel News tinklalaidės grotuvas',
+        'field_help' => 'Įklijuokite viešą Transistor bendrinimo nuorodą (https://share.transistor.fm/s/...), ir grotuvas bus įterptas automatiškai.',
+    ],
     // Admin form fields
     'basic_information' => 'Pagrindinė informacija',
     'media' => 'Medija',
@@ -122,6 +129,7 @@ return [
         'meta_title' => 'Meta pavadinimas',
         'meta_description' => 'Meta aprašymas',
         'meta_keywords' => 'Meta raktažodžiai',
+        'podcast_url' => 'Tinklalaidės bendrinimo nuoroda',
         'categories' => 'Kategorijos',
         'tags' => 'Žymės',
         'view_count' => 'Peržiūrų skaičius',

--- a/resources/views/livewire/pages/news/show.blade.php
+++ b/resources/views/livewire/pages/news/show.blade.php
@@ -11,6 +11,36 @@
 
     <div class="mt-6">{!! $record->content ?? $record->trans('content') !!}</div>
 
+    @php
+        $podcastPlayerUrl = $record->getPodcastPlayerUrl();
+        $podcastShareUrl = $record->getPodcastShareUrl();
+    @endphp
+
+    @if ($podcastPlayerUrl)
+        <section class="mt-10 bg-gray-50 border border-gray-200 rounded-xl p-6 shadow-sm">
+            <h2 class="text-2xl font-semibold text-gray-900">{{ __('news.podcast.section_title') }}</h2>
+            <p class="mt-2 text-gray-600">{{ __('news.podcast.section_description') }}</p>
+            <div class="mt-4">
+                <iframe
+                    src="{{ $podcastPlayerUrl }}"
+                    title="{{ __('news.podcast.embed_title') }}"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                    class="w-full h-48 rounded-lg border border-gray-200"
+                ></iframe>
+            </div>
+            @if ($podcastShareUrl)
+                <div class="mt-4">
+                    <a href="{{ $podcastShareUrl }}" target="_blank" rel="noopener" class="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md transition duration-200">
+                        <x-heroicon-o-play class="w-4 h-4 mr-2" />
+                        {{ __('news.podcast.listen_cta') }}
+                    </a>
+                </div>
+            @endif
+        </section>
+    @endif
+
     <!-- Back Button -->
     <div class="mt-8 text-center">
         <a href="{{ route('news.index', ['locale' => app()->getLocale()]) }}" 


### PR DESCRIPTION
## Summary
- add podcast URL normalization helpers on the News model to derive safe embed and share links
- expose a Transistor podcast share URL input inside the Filament News resource form with translated helper copy
- render the related podcast player and CTA on the public news detail view with matching EN/LT translations

## Testing
- php -l app/Models/News.php
- vendor/bin/pint app/Models/News.php
- vendor/bin/phpstan analyse app/Models/News.php -c phpstan.neon --memory-limit=1G --no-progress *(fails: existing AnalyticsResource navigation icon type error)*
- vendor/bin/rector process app/Models/News.php --ansi --no-progress-bar *(blocked: no rector.php config)*
- php -l app/Filament/Resources/NewsResource.php
- vendor/bin/pint app/Filament/Resources/NewsResource.php
- vendor/bin/phpstan analyse app/Filament/Resources/NewsResource.php -c phpstan.neon --memory-limit=1G --no-progress *(fails: existing AnalyticsResource navigation icon type error)*
- vendor/bin/rector process app/Filament/Resources/NewsResource.php --ansi --no-progress-bar *(blocked: no rector.php config)*
- php -l lang/en/news.php
- vendor/bin/pint lang/en/news.php
- vendor/bin/phpstan analyse lang/en/news.php -c phpstan.neon --memory-limit=1G --no-progress *(fails: existing AnalyticsResource navigation icon type error)*
- vendor/bin/rector process lang/en/news.php --ansi --no-progress-bar *(blocked: no rector.php config)*
- php -l lang/lt/news.php
- vendor/bin/pint lang/lt/news.php
- vendor/bin/phpstan analyse lang/lt/news.php -c phpstan.neon --memory-limit=1G --no-progress *(fails: existing AnalyticsResource navigation icon type error)*
- vendor/bin/rector process lang/lt/news.php --ansi --no-progress-bar *(blocked: no rector.php config)*
- php -l resources/views/livewire/pages/news/show.blade.php
- vendor/bin/pint resources/views/livewire/pages/news/show.blade.php
- vendor/bin/phpstan analyse resources/views/livewire/pages/news/show.blade.php -c phpstan.neon --memory-limit=1G --no-progress *(fails: existing AnalyticsResource navigation icon type error)*
- vendor/bin/rector process resources/views/livewire/pages/news/show.blade.php --ansi --no-progress-bar *(blocked: no rector.php config)*
- php artisan view:clear *(fails: existing AnalyticsResource navigation icon type error)*
- php artisan view:cache *(fails: existing AnalyticsResource navigation icon type error)*

------
https://chatgpt.com/codex/tasks/task_e_68e20e3241e483298be796dd4a8ee2f9