### PR TITLE
Fix AnalyticsResource navigation icon type

### DIFF
--- a/app/Filament/Resources/AnalyticsResource.php
+++ b/app/Filament/Resources/AnalyticsResource.php
@@ -21,7 +21,7 @@ final class AnalyticsResource extends Resource
     protected static ?string $model = Order::class;
 
     /** @var string|\BackedEnum|null */
-    protected static $navigationIcon = 'heroicon-o-chart-bar-square';
+    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-chart-bar-square';
 
     protected static UnitEnum|string|null $navigationGroup = NavigationGroup::Analytics;
 


### PR DESCRIPTION
## Summary
- align the `AnalyticsResource` navigation icon property type with Filament's base resource

## Testing
- php -l app/Filament/Resources/AnalyticsResource.php

------
https://chatgpt.com/codex/tasks/task_e_68e23660f67083299f4109c38b67ccd4