### PR TITLE
Fix AnalyticsResource navigation icon type mismatch

### DIFF
--- a/app/Filament/Resources/AnalyticsResource.php
+++ b/app/Filament/Resources/AnalyticsResource.php
@@ -21,7 +21,7 @@ final class AnalyticsResource extends Resource
     protected static ?string $model = Order::class;
 
     /** @var string|\BackedEnum|null */
-    protected static BackedEnum|string|null $navigationIcon = 'heroicon-o-chart-bar-square';
+    protected static $navigationIcon = 'heroicon-o-chart-bar-square';
 
     protected static UnitEnum|string|null $navigationGroup = NavigationGroup::Analytics;
 


### PR DESCRIPTION
## Summary
- drop the strict property type from `AnalyticsResource::$navigationIcon` while keeping the documented enum/string contract
- leave the existing icon value in place so the resource still renders with the same glyph

## Testing
- php -l app/Filament/Resources/AnalyticsResource.php
- vendor/bin/pint app/Filament/Resources/AnalyticsResource.php *(fails: `vendor/bin/pint` missing because Composer dependencies could not be installed)*
- composer install *(fails: `filament/*` packages in composer.lock are pinned to v4.0.18 but composer.json now requires ^4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68e239e28bb48329872a06d58e8883c5